### PR TITLE
added resource blank check and made small change to broken url check

### DIFF
--- a/R/add_new_dataset.R
+++ b/R/add_new_dataset.R
@@ -33,13 +33,21 @@ add_new_dataset <- function(metadata_list,
   metadata_dataset$field_wbddh_data_type   <- metadata_resources$field_wbddh_data_type
   metadata_resources$field_wbddh_data_type <- NULL
   
+  # Check for blank urls
+  blank_urls <- purrr::map(purrr::map(metadata_resources, "field_link_api"), is_blank)
+  
+  # Abort if blank URLs present
+  if(TRUE %in% blank_urls){
+    return("ABORTING HARVEST as Resources have blank URLs")
+  }
+  
   # Check if resources are leading to 404 Errors
-  broken_urls <- lapply(metadata_resources, function(x){
+  valid_urls <- lapply(metadata_resources, function(x){
     url_check(x[["field_link_api"]])
   })
   
-  # Throw error is broken URLs present
-  if(FALSE %in% broken_urls){
+  # Throw error if broken URLs present
+  if(FALSE %in% valid_urls){
     stop("Resources have broken URLs")
   }
   

--- a/R/update_existing_dataset.R
+++ b/R/update_existing_dataset.R
@@ -34,13 +34,21 @@ update_existing_dataset <- function(metadata_list,
   metadata_dataset$field_wbddh_data_type   <- metadata_resources$field_wbddh_data_type
   metadata_resources$field_wbddh_data_type <- NULL
   
+  # Check for blank urls
+  blank_urls <- purrr::map(purrr::map(metadata_resources, "field_link_api"), is_blank)
+  
+  # Abort if blank URLs present
+  if(TRUE %in% blank_urls){
+    return("ABORTING HARVEST as Resources have blank URLs")
+  }
+  
   # Check if resources are leading to 404 Errors
-  broken_urls <- lapply(metadata_resources, function(x){
+  valid_urls <- lapply(metadata_resources, function(x){
     url_check(x[["field_link_api"]])
   })
   
   # Throw error is broken URLs present
-  if(FALSE %in% broken_urls){
+  if(FALSE %in% valid_urls){
     stop("Resources have broken URLs")
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -147,7 +147,6 @@ map_resource_formats <- function(resource_metadata, lovs){
   return(output)
 }
 
-
 # Function to check if url lead to 404 Error
 url_check <- function(link){
   result <- httr::http_status(httr::GET(link))
@@ -157,3 +156,10 @@ url_check <- function(link){
     return(FALSE)
   }
 }
+
+# Check's if input is blank
+is_blank <- function(input) {
+  return(gtools::invalid(input) || all(input == ""))
+}
+
+


### PR DESCRIPTION
This is to address #25 .

The EEX Harvester has been breaking for ~3 weeks because of a single resource missing a url on the [Nepal - Multi-Tier Framework (MTF) Survey](https://energydata.info/dataset/e4526938-1f13-45b2-b4f4-467fbb02b722).

The new feature will silently ignore datasets which have any blank resources; errors won't be thrown, and hence collaborators won't be emailed by the harvested. The end goal is that the dataset will be harvested once it is updated correctly on EEX.

Has been tested in STG successfully.